### PR TITLE
Fix missing 'Input' context error

### DIFF
--- a/cultist-speedy.csproj
+++ b/cultist-speedy.csproj
@@ -18,5 +18,8 @@
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>.\externals\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>.\externals\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>    
   </ItemGroup>
 </Project>

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ This folder should include:
 - Assembly-CSharp.dll - Copied from `Cultist Simulator/cultistsimulator_Data/Managed`
 - UnityEngine.CoreModule.dll - Copied from `Cultist Simulator/cultistsimulator_Data/Managed`
 - UnityEngine.dll - Copied from `Cultist Simulator/cultistsimulator_Data/Managed`
+- UnityEngine.InputLegacyModule.dll - Copied from `Cultist Simulator/cultistsimulator_Data/Managed`
 
 ### Compiling
 


### PR DESCRIPTION
Add UnityEngine.InputLegacyModule.dll dependency to fix missing 'Input" context error on current version of game. There are same errors on your all other plugins.

[Compiled dll file if you need.](https://github.com/manbokGo/cultist-speedy/releases/tag/0.0.2)

Thanks for awesome plugin. :D 